### PR TITLE
Make Expr and Vector not Copy

### DIFF
--- a/src/operator.rs
+++ b/src/operator.rs
@@ -30,7 +30,7 @@ pub enum Operator {
     Exp = 0xD0,
     Parens = 0xE0,
     Literal = 0xF0,
-    Variable = 0xF1
+    Variable = 0xF1,
 }
 
 impl Display for Operator {
@@ -62,8 +62,7 @@ impl Display for Operator {
             Operator::BitNeg => write!(f, "~"),
             Operator::Exp => write!(f, "**"),
             Operator::Parens => write!(f, "("),
-            Operator::Literal |
-            Operator::Variable => write!(f, ""),
+            Operator::Literal | Operator::Variable => write!(f, ""),
         }
     }
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -5,7 +5,7 @@ use crate::{
     params::{Num, C_STYLE_MOD, GOAL},
 };
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Vector([Num; GOAL.len()]);
 
 impl Vector {
@@ -80,7 +80,7 @@ impl_op!(BitXor, bitxor, ^=);
 impl_op!(Shl, shl, <<=);
 impl_op!(Shr, shr, >>=);
 impl_unary!(Not, not, !);
-impl_unary!(Neg, neg, (|x|0-x));
+impl_unary!(Neg, neg, (|x| 0 - x));
 
 pub fn divmod(left: &Vector, right: &Vector) -> Option<(Vector, Vector)> {
     if left


### PR DESCRIPTION
Fixed an unnecessary copy in insert_to_level, even more faster now. Fixed rayon version compile.
A few small tweaks.
Ran `cargo fmt`.